### PR TITLE
Masking unused events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,18 @@ jobs:
         sudo apt-get install valac
         sudo apt-get install libgtk-3-dev
         sudo apt-get install libgee-0.8-dev
-        cd build_dev
-        valac --pkg gtk+-3.0 --pkg gee-0.8 --library=Caroline -H Caroline.h ../Caroline.vala -X -fPIC -X -shared -o Caroline.so
-        valac --pkg gtk+-3.0 --pkg gee-0.8 Caroline.vapi ../Sample.vala -X Caroline.so -X -I. -o demo
+        sudo apt-get install meson
+        mkdir build
+        cd build
+        meson ..
+        ninja
+        # TODO: decide what happend with this
+        #       If this is meant as a test for linking a binary against the library, this is
+        #       already tested by building the unittests. If you want to keep it, i'd recommend to
+        #       create another meson executable section.
+        # valac --pkg gtk+-3.0 --pkg gee-0.8 Caroline.vapi ../Sample.vala -X Caroline.so -X -I. -o demo
     - name: Tests 
       run: |
-        sudo apt-get install meson xorg openbox
-        meson build
-        cd build 
-      # cant run: meson test since I have no idea why but it crashes running tests here only
+        sudo apt-get install xvfb
+        cd build
+        xvfb-run ./caroline-vala

--- a/meson.build
+++ b/meson.build
@@ -12,11 +12,16 @@ deps = [
 api='0.2'
 
 lib_sources = files(
-  'Caroline.vala'
+  'src/Caroline.vala',
+  'src/types/Bar.vala',
+  'src/types/LineSmooth.vala',
+  'src/types/Line.vala',
+  'src/types/Pie.vala',
+  'src/types/Scatter.vala'
 )
 
 test_sources = files(
-  'UnitTests.vala'
+  'src/UnitTests.vala'
 )
 
 lib = shared_library('caroline-'+api, lib_sources,

--- a/src/Caroline.vala
+++ b/src/Caroline.vala
@@ -575,6 +575,30 @@ public class Caroline : Gtk.DrawingArea {
 
   }
 
+  public override void realize() {
+    Gtk.Allocation alloc;
+    this.get_allocation(out alloc);
+    var attr = Gdk.WindowAttr();
+    attr.window_type = Gdk.WindowType.CHILD;
+    attr.x = alloc.x;
+    attr.y = alloc.y;
+    attr.width = alloc.width;
+    attr.height = alloc.height;
+    attr.visual = this.get_visual();
+    attr.event_mask = this.get_events()
+         & (~Gdk.EventMask.POINTER_MOTION_MASK)
+         & (~Gdk.EventMask.LEAVE_NOTIFY_MASK)
+         & (~Gdk.EventMask.BUTTON_PRESS_MASK)
+         & (~Gdk.EventMask.BUTTON_RELEASE_MASK);
+    Gdk.WindowAttributesType mask = Gdk.WindowAttributesType.X
+         | Gdk.WindowAttributesType.X
+         | Gdk.WindowAttributesType.VISUAL;
+    var window = new Gdk.Window(this.get_parent_window(), attr, mask);
+    this.set_window(window);
+    this.register_window(window);
+    this.set_realized(true);
+  }
+
   /**
   * Sort an array list
   *


### PR DESCRIPTION
Implemented the realize function for Caroline.
I am using caroline in a context where a container element must handle mouse movent events (motion_notify_event in Glib-speak) that originate in Caroline.
Currently this seems be some kind of undefined behaviour and it sends somewhat weird events to the parent where the relative mouse coordinates seem to be falsely passed as absolute coordinates, leading to weird behaviour in my container.
As Caroline is a display widget it makes sense to deactivate unused signals altogether until they are used and properly implemented.